### PR TITLE
Upgraded amundsen submodule's version

### DIFF
--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -12,7 +12,7 @@ COPY amundsen/frontend/amundsen_application/static /app/amundsen_application/sta
 COPY frontend/static /app/amundsen_application/static
 RUN npm run build
 
-FROM python:3.7-slim as base
+FROM python:3.8-slim as base
 WORKDIR /app
 RUN pip3 install gunicorn
 

--- a/frontend/static/js/config/config-custom.ts
+++ b/frontend/static/js/config/config-custom.ts
@@ -3,9 +3,11 @@
 import { AppConfigCustom } from './config-types';
 
 const configCustom: AppConfigCustom = {
-  browse: {
+   browse: {
     curatedTags: [],
+    hideNonClickableBadges: false,
     showAllTags: true,
+    showBadgesInHome: true,
   },
   analytics: {
     plugins: [],
@@ -31,6 +33,7 @@ const configCustom: AppConfigCustom = {
     inAppListEnabled: true,
     inAppPageEnabled: true,
     externalEnabled: true,
+    defaultLineageDepth: 5,
     iconPath: 'PATH_TO_ICON',
     isBeta: false,
     urlGenerator: (


### PR DESCRIPTION
1. Pinned the the amundsen submodule to [search-4.2.0](https://github.com/amundsen-io/amundsen/releases/tag/search-4.2.0), which is the latest release and contains `frontend-4.3.0`.
2. Build a new custom frontend image `933794580186.dkr.ecr.us-east-1.amazonaws.com/data-platform/kt-amundsen-frontend:4.3.0-user-enabled`, which is the same as `frontend-4.3.0` but with a `config-custom.ts` specified to enable features such as table lineage.